### PR TITLE
Fix Home debtors list adapter rx schedulers update on lowend devices

### DIFF
--- a/app/src/main/java/debts/common/android/extensions/AndroidVersion.kt
+++ b/app/src/main/java/debts/common/android/extensions/AndroidVersion.kt
@@ -1,0 +1,16 @@
+package debts.common.android.extensions
+
+import android.os.Build
+
+/**
+ * >= android-7.1, Api 25
+ */
+fun atLeastNougatMr1() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1
+
+/**
+ * >= android-7.1, Api 25
+ */
+fun ifAtLeastNougatMr1(callback: () -> Unit) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1)
+        callback()
+}

--- a/app/src/main/java/debts/home/list/adapter/DebtorsAdapter.kt
+++ b/app/src/main/java/debts/home/list/adapter/DebtorsAdapter.kt
@@ -2,11 +2,7 @@ package debts.home.list.adapter
 
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
-import debts.common.android.adapters.CommonDiffUtilCallback
-import debts.common.android.adapters.DelegatedAdapter
-import debts.common.android.adapters.ItemRenderer
-import debts.common.android.adapters.TypedAdapterDelegate
-import debts.common.android.adapters.ViewHolderRenderer
+import debts.common.android.adapters.*
 import debts.common.android.extensions.*
 import io.reactivex.Completable
 import io.reactivex.Single
@@ -58,16 +54,24 @@ class DebtorsAdapter(
     }
 
     fun setItems(newItems: List<DebtorsItemViewModel>): Completable {
-        return Single.fromCallable<DiffUtil.DiffResult> {
-            DiffUtil.calculateDiff(CommonDiffUtilCallback(items, newItems))
-        }
-            .subscribeOn(Schedulers.computation())
-            .observeOn(AndroidSchedulers.mainThread())
-            .doOnSuccess { result ->
-                this.items = newItems
-                result.dispatchUpdatesTo(this)
+        return Single.fromCallable { atLeastNougatMr1() }
+            .flatMapCompletable { atLeastNougatMr1 ->
+                if (atLeastNougatMr1) {
+                    Single.fromCallable {
+                        DiffUtil.calculateDiff(CommonDiffUtilCallback(items, newItems))
+                    }
+                        .subscribeOn(Schedulers.computation())
+                        .observeOn(AndroidSchedulers.mainThread())
+                } else {
+                    Single.fromCallable {
+                        DiffUtil.calculateDiff(CommonDiffUtilCallback(items, newItems))
+                    }
+                }.doOnSuccess { result ->
+                    this.items = newItems
+                    result.dispatchUpdatesTo(this)
+                }
+                    .ignoreElement()
             }
-            .ignoreElement()
     }
 
     fun replaceAllItems(newItems: List<DebtorsItemViewModel>) {


### PR DESCRIPTION
```
.subscribeOn(Schedulers.computation())
.observeOn(AndroidSchedulers.mainThread())
```

doesn't work for api < 25
also affects update of adapter