### PR TITLE
feat(test): add test infrastructure — MockK, Turbine, Kover (F0.2)

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -52,6 +52,9 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             dependencies {
                 add("androidTestImplementation", kotlin("test"))
                 add("testImplementation", kotlin("test"))
+                add("testImplementation", libs.findLibrary("mockk").get())
+                add("testImplementation", libs.findLibrary("kotlinx.coroutines.test").get())
+                add("testImplementation", libs.findLibrary("turbine").get())
                 add("implementation", libs.findLibrary("timber").get())
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.triplet.play) apply (false)
     alias(libs.plugins.detekt)
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.kover) apply false
 }
 
 detekt {

--- a/core/repository/build.gradle.kts
+++ b/core/repository/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.debts.android.library)
+    alias(libs.plugins.kover)
 }
 
 android {

--- a/core/repository/src/test/kotlin/debts/core/repository/MappersTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/repository/MappersTest.kt
@@ -1,0 +1,86 @@
+package debts.core.repository
+
+import debts.core.db.DebtEntity
+import debts.core.db.DebtorEntity
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MappersTest {
+
+    @Test
+    fun `DebtorEntity maps to DebtorModel`() {
+        val entity = DebtorEntity(
+            id = 1L,
+            contactId = 42L,
+            name = "John Doe",
+            avatarUrl = "https://example.com/avatar.jpg",
+            email = "",
+            phone = "",
+        )
+
+        val model = entity.toDebtorModel()
+
+        assertEquals(1L, model.id)
+        assertEquals("John Doe", model.name)
+        assertEquals(42L, model.contactId)
+        assertEquals("https://example.com/avatar.jpg", model.avatarUrl)
+    }
+
+    @Test
+    fun `DebtorEntity with null contactId maps to DebtorModel with null contactId`() {
+        val entity = DebtorEntity(
+            id = 2L,
+            contactId = null,
+            name = "Jane Doe",
+            avatarUrl = "",
+            email = "",
+            phone = "",
+        )
+
+        val model = entity.toDebtorModel()
+
+        assertEquals(2L, model.id)
+        assertNull(model.contactId)
+    }
+
+    @Test
+    fun `DebtEntity maps to DebtModel`() {
+        val entity = DebtEntity(
+            id = 10L,
+            debtorId = 1L,
+            amount = 150.5,
+            currency = "USD",
+            date = 1_700_000_000L,
+            comment = "Lunch",
+        )
+
+        val model = entity.toDebtModel()
+
+        assertEquals(10L, model.id)
+        assertEquals(1L, model.debtorId)
+        assertEquals(150.5, model.amount)
+        assertEquals("USD", model.currency)
+        assertEquals(1_700_000_000L, model.date)
+        assertEquals("Lunch", model.comment)
+    }
+
+    @Test
+    fun `DebtorModel maps to DebtorEntity with empty legacy fields`() {
+        val model = debts.core.repository.data.DebtorModel(
+            id = 5L,
+            name = "Alice",
+            contactId = 100L,
+            avatarUrl = "https://example.com/alice.jpg",
+        )
+
+        val entity = model.toDebtorEntity()
+
+        assertEquals(5L, entity.id)
+        assertEquals(100L, entity.contactId)
+        assertEquals("Alice", entity.name)
+        assertEquals("https://example.com/alice.jpg", entity.avatarUrl)
+        assertEquals("", entity.email)
+        assertEquals("", entity.phone)
+    }
+}

--- a/core/repository/src/test/kotlin/debts/core/repository/MappersTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/repository/MappersTest.kt
@@ -66,7 +66,7 @@ class MappersTest {
     }
 
     @Test
-    fun `DebtorModel maps to DebtorEntity with empty legacy fields`() {
+    fun `DebtorModel maps to DebtorEntity with email and phone defaulting to empty string`() {
         val model = debts.core.repository.data.DebtorModel(
             id = 5L,
             name = "Alice",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,11 @@ androidx-core = "1.12.0"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.3.2"
 detekt = "1.23.8"
+kover = "0.9.8"
+kotlinx-coroutines = "1.9.0"
+mockk = "1.13.17"
+robolectric = "4.16.1"
+turbine = "1.2.1"
 firebase-bom = "32.7.0"
 firebase-crashlytics-gradle = "2.9.9"
 java = "17"
@@ -61,6 +66,10 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 # Dependencies of the included build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "android-gradle-plugin" }
@@ -80,6 +89,7 @@ firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "
 google-services = { id = "com.google.gms.google-services", version.ref = "google-services" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 triplet-play = { id = "com.github.triplet.play", version.ref = "triplet-play" }
 


### PR DESCRIPTION
## Story F0.2 — Test Infrastructure

> **Note:** branched from `story/f0.1-tooling-bump`, not `master`. Will be rebased onto `master` after F0.1 is merged.

### What's added

**Version catalog**
| Library | Version |
|---|---|
| MockK | 1.13.17 |
| kotlinx-coroutines-test | 1.9.0 |
| Turbine | 1.2.1 |
| Robolectric | 4.16.1 |
| Kover | 0.9.8 |

**Convention plugin** (`AndroidLibraryConventionPlugin`)
All library modules automatically get as `testImplementation`:
- `kotlin("test")` — was already there
- `mockk` — mocking
- `kotlinx-coroutines-test` — `runTest`, `TestCoroutineScheduler`, `advanceUntilIdle`
- `turbine` — `Flow.test {}` assertions

Robolectric stays opt-in (added to catalog, not wired into convention plugin — needed selectively for DAO tests in D1.1).

**Coverage** (Kover 0.9.8)
Applied in `core:repository`. No threshold yet — enforcement added in F0.3.
- `./gradlew :core:repository:koverHtmlReport` → `build/reports/kover/html/index.html`
- `./gradlew :core:repository:koverXmlReport` → for CI consumption

**Sample tests** (`core/repository/src/test/`)
4 unit tests for `Mappers.kt` covering all three mapper functions:
- `DebtorEntity.toDebtorModel()` — happy path + null `contactId` edge case
- `DebtEntity.toDebtModel()` — all fields
- `DebtorModel.toDebtorEntity()` — checks legacy `email`/`phone` fields default to `""`

### Acceptance

- [x] `./gradlew :core:repository:test` — BUILD SUCCESSFUL, 4 tests pass
- [x] `./gradlew :core:repository:koverHtmlReport` — report generated