### PR TITLE
feat(ui): migrate theme M2 → M3 Light baseline, force light theme (F0.4)

### DIFF
--- a/app/src/main/java/debts/DebtsApp.kt
+++ b/app/src/main/java/debts/DebtsApp.kt
@@ -1,6 +1,7 @@
 package debts
 
 import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
 import debts.common.TimberCrashlyticsTree
 import debts.di.appModule
 import debts.di.interactorModule
@@ -16,6 +17,7 @@ import timber.log.Timber
 class DebtsApp : Application() {
 
     override fun onCreate() {
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())

--- a/core/common/src/main/kotlin/debts/core/common/android/BaseActivity.kt
+++ b/core/common/src/main/kotlin/debts/core/common/android/BaseActivity.kt
@@ -2,9 +2,19 @@ package debts.core.common.android
 
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.Fragment
 
 abstract class BaseActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        // Disable edge-to-edge for the transitional period while Views still lack insets handling.
+        // Must be called AFTER super.onCreate(): Android 15 (API 35) auto-calls
+        // setDecorFitsSystemWindows(false) inside Activity.onCreate() for targetSdk 35+,
+        // which would override a pre-super call. Remove in U2.6 when all screens are on Compose.
+        WindowCompat.setDecorFitsSystemWindows(window, true)
+    }
 
     fun replaceFragment(
         fragment: Fragment,

--- a/core/resource/src/main/res/values/styles.xml
+++ b/core/resource/src/main/res/values/styles.xml
@@ -2,16 +2,22 @@
 
     <style name="Debts" />
 
-    <style name="Debts.Theme" parent="Theme.MaterialComponents.Light.NoActionBar">
+    <style name="Debts.Theme" parent="Theme.Material3.Light.NoActionBar">
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <!-- colorAccent for AppCompat/M2 widgets; colorSecondary for M3 widgets — both map to the brand accent -->
         <item name="colorAccent">@color/colorAccent</item>
-        <item name="android:navigationBarColor">@color/colorPrimary</item>
+        <item name="colorSecondary">@color/colorAccent</item>
+        <!-- Android 15+: bars are transparent; windowBackground shows through the fitsSystemWindows padding areas -->
+        <!-- Pre-15: statusBarColor/navigationBarColor apply directly -->
+        <item name="android:windowBackground">@color/colorPrimaryDark</item>
+        <item name="android:statusBarColor">@color/colorPrimaryDark</item>
+        <item name="android:navigationBarColor">@color/colorPrimaryDark</item>
     </style>
 
     <!-- Text Input-->
 
-    <style name="Debts.Theme.TextInput" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox">
+    <style name="Debts.Theme.TextInput" parent="Widget.Material3.TextInputLayout.OutlinedBox">
         <item name="android:textColor">@color/debts_grey</item>
         <item name="android:textSize">18sp</item>
         <item name="android:textCursorDrawable">@null</item>
@@ -27,7 +33,7 @@
         <item name="android:textSize">@dimen/text_size_12sp</item>
     </style>
 
-    <style name="Debts.Theme.TextAutocompleteInput" parent="Widget.MaterialComponents.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
+    <style name="Debts.Theme.TextAutocompleteInput" parent="Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu">
         <item name="android:textColor">@color/debts_grey</item>
         <item name="android:textSize">18sp</item>
         <item name="android:textCursorDrawable">@null</item>
@@ -42,10 +48,15 @@
 
     <!-- Tabs -->
 
-    <style name="Debts.Tabs" parent="Widget.MaterialComponents.TabLayout">
+    <style name="Debts.Tabs" parent="Widget.Material3.TabLayout">
         <item name="android:background">@color/debts_white_pressed</item>
         <item name="tabTextColor">@color/tabs_color</item>
         <item name="tabIndicatorColor">@color/debts_accent_pressed</item>
+        <item name="tabTextAppearance">@style/Debts.Tabs.Label</item>
+    </style>
+
+    <style name="Debts.Tabs.Label" parent="TextAppearance.Material3.TitleSmall">
+        <item name="textAllCaps">true</item>
     </style>
 
     <!-- Text -->
@@ -142,7 +153,7 @@
         <item name="android:textColor">@color/button_accent_text_color_selector</item>
     </style>
 
-    <style name="Debts.FloatingButton" parent="Widget.MaterialComponents.FloatingActionButton">
+    <style name="Debts.FloatingButton" parent="Widget.Material3.FloatingActionButton.Primary">
         <item name="backgroundTint">@color/colorAccent</item>
         <item name="tint">@color/debts_white</item>
     </style>

--- a/feature/details/src/main/res/layout/details_activity.xml
+++ b/feature/details/src/main/res/layout/details_activity.xml
@@ -3,4 +3,5 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/details_root"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true" />

--- a/feature/home/src/main/res/layout/home_activity.xml
+++ b/feature/home/src/main/res/layout/home_activity.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/home_toolbar"

--- a/feature/preferences/src/main/res/layout/preferences_activity.xml
+++ b/feature/preferences/src/main/res/layout/preferences_activity.xml
@@ -3,6 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical">
 
     <androidx.appcompat.widget.Toolbar


### PR DESCRIPTION
## Summary

- Migrates parent theme from `Theme.MaterialComponents.Light.NoActionBar` to `Theme.Material3.Light.NoActionBar`
- Forces light-only mode via `AppCompatDelegate.MODE_NIGHT_NO` in `Application.onCreate()` — dark theme deferred to U2.6 when all UI is on Compose
- Migrates widget styles: `TextInputLayout`, `TabLayout`, `FAB` to M3 equivalents
- Restores tab ALLCAPS behaviour lost in M3 via explicit `Debts.Tabs.Label` style with `textAllCaps=true`
- Opts out of Android 15 forced edge-to-edge (transitional fix for Views): `WindowCompat.setDecorFitsSystemWindows(window, true)` in `BaseActivity` + `android:fitsSystemWindows="true"` on all activity root layouts
- Restores system bar colour (Android 15 ignores `window.statusBarColor` in edge-to-edge mode): `android:windowBackground=@color/colorPrimaryDark` in theme — transparent bars on API 35+ show window background through `fitsSystemWindows` padding areas; `android:statusBarColor`/`navigationBarColor` remain for pre-15 devices

## Test plan

- [ ] App launches in light theme on Android 15 emulator (API 35+)
- [ ] Status bar and navigation bar are teal (`colorPrimaryDark` #34c7d9), not grey
- [ ] Toolbar and tab labels are not clipped by status bar
- [ ] Tab labels are ALL CAPS
- [ ] FAB is rounded rectangle (M3 shape), pink accent fill
- [ ] Text input fields render correctly (outlined box style)
- [ ] Preferences screen renders without overlap at bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)