### PR TITLE
feat(db): migrate DAO from RxJava to coroutines (D1.1)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(project(":feature:preferences"))
 
     implementation(libs.koin)
+    implementation(libs.bundles.rxjava)
 
     debugImplementation(libs.leak.canary)
 }

--- a/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidRoomConventionPlugin.kt
@@ -43,7 +43,6 @@ class AndroidRoomConventionPlugin : Plugin<Project> {
 
             dependencies {
                 add("implementation", libs.findLibrary("room.runtime").get())
-                add("implementation", libs.findLibrary("room.rxjava2").get())
                 add("implementation", libs.findLibrary("room.ktx").get())
                 add("ksp", libs.findLibrary("room.compiler").get())
                 add("testImplementation", libs.findLibrary("room.testing").get())

--- a/core/db/build.gradle.kts
+++ b/core/db/build.gradle.kts
@@ -8,4 +8,6 @@ android {
 }
 
 dependencies {
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
 }

--- a/core/db/src/main/kotlin/debts/core/db/DebtsDB.kt
+++ b/core/db/src/main/kotlin/debts/core/db/DebtsDB.kt
@@ -8,9 +8,7 @@ import androidx.room.Query
 import androidx.room.RoomDatabase
 import androidx.room.Transaction
 import androidx.room.Update
-import io.reactivex.Completable
-import io.reactivex.Observable
-import io.reactivex.Single
+import kotlinx.coroutines.flow.Flow
 
 @Database(
     version = DebtsDatabase.DB_VERSION,
@@ -35,57 +33,57 @@ abstract class DebtsDatabase : RoomDatabase() {
 abstract class DebtsDao {
 
     @Insert
-    abstract fun insertDebtor(debtorEntity: DebtorEntity): Single<Long>
+    abstract suspend fun insertDebtor(debtorEntity: DebtorEntity): Long
 
     @Insert
-    abstract fun insertDebt(debtEntity: DebtEntity): Single<Long>
+    abstract suspend fun insertDebt(debtEntity: DebtEntity): Long
 
     @Update
-    abstract fun updateDebtor(debtorEntity: DebtorEntity): Completable
+    abstract suspend fun updateDebtor(debtorEntity: DebtorEntity)
 
     @Query("UPDATE ${DebtorEntity.TABLE_NAME} SET ${DebtorEntity.NAME} = :name, ${DebtorEntity.AVATAR} = :avatar WHERE ${DebtorEntity.ID} = :id")
-    abstract fun updateDebtor(id: Long, name: String, avatar: String)
+    abstract suspend fun updateDebtor(id: Long, name: String, avatar: String)
 
     @Transaction
-    open fun updateDebtors(debtors: List<DebtorEntity>) {
+    open suspend fun updateDebtors(debtors: List<DebtorEntity>) {
         for (item in debtors) {
             updateDebtor(item.id, item.name, item.avatarUrl)
         }
     }
 
     @Update
-    abstract fun updateDebt(debtEntity: DebtEntity): Completable
+    abstract suspend fun updateDebt(debtEntity: DebtEntity)
 
     @Query("UPDATE ${DebtEntity.TABLE_NAME} SET ${DebtEntity.CURRENCY} = :currency")
-    abstract fun updateDebtsCurrency(currency: String)
+    abstract suspend fun updateDebtsCurrency(currency: String)
 
     @Delete
-    abstract fun deleteDebtor(debtorEntity: DebtorEntity): Completable
+    abstract suspend fun deleteDebtor(debtorEntity: DebtorEntity)
 
     @Delete
-    abstract fun deleteDebt(debtEntity: DebtEntity): Completable
+    abstract suspend fun deleteDebt(debtEntity: DebtEntity)
 
     @Query("DELETE FROM ${DebtorEntity.TABLE_NAME} WHERE ${DebtorEntity.ID} = :id")
-    abstract fun deleteDebtor(id: Long): Completable
+    abstract suspend fun deleteDebtor(id: Long)
 
     @Query("DELETE FROM ${DebtEntity.TABLE_NAME} WHERE ${DebtEntity.DEBTOR_ID} = :debtorId")
-    abstract fun clearAllDebts(debtorId: Long): Completable
+    abstract suspend fun clearAllDebts(debtorId: Long)
 
     @Query("SELECT * FROM ${DebtorEntity.TABLE_NAME} WHERE ${DebtorEntity.ID} = :id")
-    abstract fun observeDebtor(id: Long): Observable<DebtorEntity>
+    abstract fun observeDebtor(id: Long): Flow<DebtorEntity?>
 
     @Query("SELECT * FROM ${DebtorEntity.TABLE_NAME}")
-    abstract fun observeDebtors(): Observable<List<DebtorEntity>>
+    abstract fun observeDebtors(): Flow<List<DebtorEntity>>
 
     @Query("SELECT * FROM ${DebtEntity.TABLE_NAME}")
-    abstract fun observeDebts(): Observable<List<DebtEntity>>
+    abstract fun observeDebts(): Flow<List<DebtEntity>>
 
     @Query("SELECT * FROM ${DebtEntity.TABLE_NAME} WHERE ${DebtEntity.ID} = :id")
-    abstract fun getDebt(id: Long): Single<DebtEntity>
+    abstract suspend fun getDebt(id: Long): DebtEntity
 
     @Query("SELECT * FROM ${DebtEntity.TABLE_NAME} WHERE ${DebtEntity.DEBTOR_ID} = :debtorId")
-    abstract fun observeDebts(debtorId: Long): Observable<List<DebtEntity>>
+    abstract fun observeDebts(debtorId: Long): Flow<List<DebtEntity>>
 
     @Query("DELETE FROM ${DebtEntity.TABLE_NAME} WHERE ${DebtEntity.ID} = :id")
-    abstract fun deleteDebt(id: Long): Completable
+    abstract suspend fun deleteDebt(id: Long)
 }

--- a/core/db/src/test/kotlin/debts/core/db/DebtsDaoTest.kt
+++ b/core/db/src/test/kotlin/debts/core/db/DebtsDaoTest.kt
@@ -1,0 +1,242 @@
+package debts.core.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@RunWith(RobolectricTestRunner::class)
+class DebtsDaoTest {
+
+    private lateinit var db: DebtsDatabase
+    private lateinit var dao: DebtsDao
+
+    @Before
+    fun setUp() {
+        db = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            DebtsDatabase::class.java,
+        )
+            .allowMainThreadQueries()
+            .build()
+        dao = db.debtsDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    // region DebtorEntity
+
+    @Test
+    fun `insertDebtor returns generated id`() = runTest {
+        val id = dao.insertDebtor(debtorEntity(id = 0))
+
+        assertNotEquals(0L, id)
+    }
+
+    @Test
+    fun `observeDebtors emits inserted debtor`() = runTest {
+        val debtor = debtorEntity(id = 0, name = "Alice")
+        dao.insertDebtor(debtor)
+
+        dao.observeDebtors().test {
+            val items = awaitItem()
+            assertEquals(1, items.size)
+            assertEquals("Alice", items.first().name)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `observeDebtors emits empty list when no rows`() = runTest {
+        dao.observeDebtors().test {
+            assertTrue(awaitItem().isEmpty())
+            cancel()
+        }
+    }
+
+    @Test
+    fun `observeDebtor emits null when row does not exist`() = runTest {
+        dao.observeDebtor(id = 999L).test {
+            assertNull(awaitItem())
+            cancel()
+        }
+    }
+
+    @Test
+    fun `updateDebtor by entity changes stored values`() = runTest {
+        val id = dao.insertDebtor(debtorEntity(id = 0, name = "Bob"))
+        dao.updateDebtor(debtorEntity(id = id, name = "Bobby"))
+
+        dao.observeDebtors().test {
+            assertEquals("Bobby", awaitItem().first().name)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `deleteDebtor by id removes the row`() = runTest {
+        val id = dao.insertDebtor(debtorEntity(id = 0))
+        dao.deleteDebtor(id)
+
+        dao.observeDebtors().test {
+            assertTrue(awaitItem().isEmpty())
+            cancel()
+        }
+    }
+
+    @Test
+    fun `updateDebtors updates multiple rows in one transaction`() = runTest {
+        val id1 = dao.insertDebtor(debtorEntity(id = 0, name = "A", avatar = "old"))
+        val id2 = dao.insertDebtor(debtorEntity(id = 0, name = "B", avatar = "old"))
+
+        dao.updateDebtors(
+            listOf(
+                debtorEntity(id = id1, name = "A", avatar = "new1"),
+                debtorEntity(id = id2, name = "B", avatar = "new2"),
+            )
+        )
+
+        dao.observeDebtors().test {
+            val items = awaitItem().sortedBy { it.id }
+            assertEquals("new1", items[0].avatarUrl)
+            assertEquals("new2", items[1].avatarUrl)
+            cancel()
+        }
+    }
+
+    // endregion
+
+    // region DebtEntity
+
+    @Test
+    fun `insertDebt returns generated id`() = runTest {
+        val debtorId = dao.insertDebtor(debtorEntity(id = 0))
+
+        val id = dao.insertDebt(debtEntity(id = 0, debtorId = debtorId))
+
+        assertNotEquals(0L, id)
+    }
+
+    @Test
+    fun `observeDebts emits inserted debt`() = runTest {
+        val debtorId = dao.insertDebtor(debtorEntity(id = 0))
+        dao.insertDebt(debtEntity(id = 0, debtorId = debtorId, amount = 42.0))
+
+        dao.observeDebts().test {
+            val items = awaitItem()
+            assertEquals(1, items.size)
+            assertEquals(42.0, items.first().amount)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `observeDebts filtered by debtorId returns only matching rows`() = runTest {
+        val debtorId1 = dao.insertDebtor(debtorEntity(id = 0, name = "A"))
+        val debtorId2 = dao.insertDebtor(debtorEntity(id = 0, name = "B"))
+        dao.insertDebt(debtEntity(id = 0, debtorId = debtorId1, amount = 10.0))
+        dao.insertDebt(debtEntity(id = 0, debtorId = debtorId2, amount = 20.0))
+
+        dao.observeDebts(debtorId = debtorId1).test {
+            val items = awaitItem()
+            assertEquals(1, items.size)
+            assertEquals(10.0, items.first().amount)
+            cancel()
+        }
+    }
+
+    @Test
+    fun `getDebt returns the correct entity`() = runTest {
+        val debtorId = dao.insertDebtor(debtorEntity(id = 0))
+        val debtId = dao.insertDebt(debtEntity(id = 0, debtorId = debtorId, amount = 99.0))
+
+        val debt = dao.getDebt(debtId)
+
+        assertEquals(99.0, debt.amount)
+    }
+
+    @Test
+    fun `deleteDebt by id removes the row`() = runTest {
+        val debtorId = dao.insertDebtor(debtorEntity(id = 0))
+        val debtId = dao.insertDebt(debtEntity(id = 0, debtorId = debtorId))
+        dao.deleteDebt(debtId)
+
+        dao.observeDebts().test {
+            assertTrue(awaitItem().isEmpty())
+            cancel()
+        }
+    }
+
+    @Test
+    fun `clearAllDebts removes all debts for debtor`() = runTest {
+        val debtorId = dao.insertDebtor(debtorEntity(id = 0))
+        dao.insertDebt(debtEntity(id = 0, debtorId = debtorId, amount = 1.0))
+        dao.insertDebt(debtEntity(id = 0, debtorId = debtorId, amount = 2.0))
+        dao.clearAllDebts(debtorId)
+
+        dao.observeDebts(debtorId = debtorId).test {
+            assertTrue(awaitItem().isEmpty())
+            cancel()
+        }
+    }
+
+    @Test
+    fun `updateDebtsCurrency updates currency on all debts`() = runTest {
+        val debtorId = dao.insertDebtor(debtorEntity(id = 0))
+        dao.insertDebt(debtEntity(id = 0, debtorId = debtorId, currency = "USD"))
+        dao.insertDebt(debtEntity(id = 0, debtorId = debtorId, currency = "USD"))
+
+        dao.updateDebtsCurrency("EUR")
+
+        dao.observeDebts().test {
+            val items = awaitItem()
+            assertTrue(items.all { it.currency == "EUR" })
+            cancel()
+        }
+    }
+
+    // endregion
+
+    // region helpers
+
+    private fun debtorEntity(
+        id: Long,
+        name: String = "Name",
+        avatar: String = "",
+    ) = DebtorEntity(
+        id = id,
+        contactId = null,
+        name = name,
+        avatarUrl = avatar,
+        email = "",
+        phone = "",
+    )
+
+    private fun debtEntity(
+        id: Long,
+        debtorId: Long,
+        amount: Double = 0.0,
+        currency: String = "USD",
+    ) = DebtEntity(
+        id = id,
+        debtorId = debtorId,
+        amount = amount,
+        currency = currency,
+        date = 0L,
+        comment = "",
+    )
+
+    // endregion
+}

--- a/core/repository/build.gradle.kts
+++ b/core/repository/build.gradle.kts
@@ -11,4 +11,7 @@ dependencies {
     implementation(project(":core:db"))
 
     implementation(libs.bundles.rxjava)
+    // Temporary interop bridge: DAO is on coroutines, repository public API is still RxJava.
+    // Removed in D1.2 when the repository is migrated to suspend/Flow.
+    implementation(libs.kotlinx.coroutines.rx2)
 }

--- a/core/repository/src/main/kotlin/debts/core/repository/DebtsRepository.kt
+++ b/core/repository/src/main/kotlin/debts/core/repository/DebtsRepository.kt
@@ -12,6 +12,11 @@ import debts.core.repository.data.DebtorModel
 import io.reactivex.Completable
 import io.reactivex.Observable
 import io.reactivex.Single
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.rx2.asObservable
+import kotlinx.coroutines.rx2.rxCompletable
+import kotlinx.coroutines.rx2.rxSingle
 
 @Suppress("TooManyFunctions")
 class DebtsRepository(
@@ -29,11 +34,16 @@ class DebtsRepository(
         const val PREFS_FILTER_KEY = "PREFS_FILTER_KEY"
     }
 
-    fun observeDebtors(): Observable<List<DebtorModel>> = dao.observeDebtors()
-        .map { items -> items.map { it.toDebtorModel() } }
+    fun observeDebtors(): Observable<List<DebtorModel>> =
+        dao.observeDebtors()
+            .map { items -> items.map { it.toDebtorModel() } }
+            .asObservable()
 
-    fun observeDebtor(debtorId: Long): Observable<DebtorModel> = dao.observeDebtor(debtorId)
-        .map { items -> items.toDebtorModel() }
+    fun observeDebtor(debtorId: Long): Observable<DebtorModel> =
+        dao.observeDebtor(debtorId)
+            .filterNotNull()
+            .map { it.toDebtorModel() }
+            .asObservable()
 
     fun getDebtors(): Single<List<DebtorModel>> =
         observeDebtors()
@@ -41,12 +51,12 @@ class DebtsRepository(
             .single(emptyList())
 
     fun getDebt(debtId: Long): Single<DebtModel> =
-        dao.getDebt(debtId)
-            .map { it.toDebtModel() }
+        rxSingle { dao.getDebt(debtId).toDebtModel() }
 
     fun observeDebts(debtorId: Long = 0): Observable<List<DebtModel>> =
         (if (debtorId == 0L) dao.observeDebts() else dao.observeDebts(debtorId))
             .map { items -> items.map { it.toDebtModel() } }
+            .asObservable()
 
     fun getDebts(debtorId: Long = 0L): Single<List<DebtModel>> =
         observeDebts(debtorId)
@@ -93,21 +103,21 @@ class DebtsRepository(
         email: String = "",
         phone: String = "",
     ): Single<Long> =
-        dao.insertDebtor(
-            DebtorEntity(
-                INSERT_ID,
-                contactId,
-                name,
-                avatarUrl,
-                email,
-                phone
+        rxSingle {
+            dao.insertDebtor(
+                DebtorEntity(
+                    INSERT_ID,
+                    contactId,
+                    name,
+                    avatarUrl,
+                    email,
+                    phone
+                )
             )
-        )
+        }
 
     fun updateDebtors(items: List<DebtorModel>): Completable =
-        Completable.fromCallable {
-            dao.updateDebtors(items.map { it.toDebtorEntity() })
-        }
+        rxCompletable { dao.updateDebtors(items.map { it.toDebtorEntity() }) }
 
     fun saveDebt(
         debtorId: Long,
@@ -116,16 +126,18 @@ class DebtsRepository(
         comment: String,
         date: Long,
     ): Single<Long> =
-        dao.insertDebt(
-            DebtEntity(
-                INSERT_ID,
-                debtorId,
-                amount,
-                currency,
-                date,
-                comment
+        rxSingle {
+            dao.insertDebt(
+                DebtEntity(
+                    INSERT_ID,
+                    debtorId,
+                    amount,
+                    currency,
+                    date,
+                    comment
+                )
             )
-        )
+        }
 
     fun updateDebt(
         id: Long,
@@ -134,20 +146,19 @@ class DebtsRepository(
         currency: String,
         date: Long,
         comment: String,
-    ): Completable = dao.updateDebt(
-        DebtEntity(id, debtorId, amount, currency, date, comment)
-    )
+    ): Completable =
+        rxCompletable { dao.updateDebt(DebtEntity(id, debtorId, amount, currency, date, comment)) }
 
-    fun clearDebts(debtorId: Long): Completable = dao.clearAllDebts(debtorId)
+    fun clearDebts(debtorId: Long): Completable = rxCompletable { dao.clearAllDebts(debtorId) }
 
-    fun removeDebt(id: Long): Completable = dao.deleteDebt(id)
+    fun removeDebt(id: Long): Completable = rxCompletable { dao.deleteDebt(id) }
 
     fun updateDebtsCurrency(): Completable = getCurrency()
-        .flatMapCompletable {
-            Completable.fromCallable { dao.updateDebtsCurrency(it) }
+        .flatMapCompletable { currency ->
+            rxCompletable { dao.updateDebtsCurrency(currency) }
         }
 
-    fun removeDebtor(debtorId: Long): Completable = dao.deleteDebtor(debtorId)
+    fun removeDebtor(debtorId: Long): Completable = rxCompletable { dao.deleteDebtor(debtorId) }
 
     // region Preferences
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,6 @@ leak-canary = { module = "com.squareup.leakcanary:leakcanary-android", version.r
 room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }
 room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 room-ktx = { module = "androidx.room:room-ktx", version.ref = "room" }
-room-rxjava2 = { module = "androidx.room:room-rxjava2", version.ref = "room" }
 room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
 rxbinding = { module = "com.jakewharton.rxbinding3:rxbinding", version.ref = "rxbinding3" }
 rxjava2-rxandroid = { module = "io.reactivex.rxjava2:rxandroid", version.ref = "rxjava2-rxandroid" }
@@ -63,9 +62,11 @@ rxjava2-rxjava = { module = "io.reactivex.rxjava2:rxjava", version.ref = "rxjava
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 # Testing
+androidx-test-core = { group = "androidx.test", name = "core-ktx", version = "1.6.1" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+kotlinx-coroutines-rx2 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-rx2", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
## Summary

- Converts all `DebtsDao` methods from RxJava (`Single<T>` / `Completable` / `Observable<T>`) to coroutines (`suspend` / `Flow<T>`)
- `observeDebtor` returns `Flow<DebtorEntity?>` — Room emits `null` when the row doesn't exist (safe nullable contract)
- `updateDebtors` is now `open suspend fun` inside `@Transaction`
- Removes `room-rxjava2` from the Room convention plugin; adds explicit `rxjava` dependency to `app` module (was previously implicit via `room-rxjava2` transitive)
- Bridges the repository public API (still RxJava, migrated in D1.2) to the new coroutine DAO via `kotlinx-coroutines-rx2` (`rxSingle` / `rxCompletable` / `Flow.asObservable()`)
- Adds 12 DAO unit tests with in-memory Room + Robolectric covering inserts, observe, update, delete, batch transaction, currency update

## Test plan

- [ ] `./gradlew :core:db:test` — all 12 DAO tests pass
- [ ] `./gradlew assembleDebug` — builds successfully
- [ ] `./gradlew test koverVerify` — all tests pass, coverage threshold met
- [ ] App launches and functions correctly (debtors list, add/edit debt, details)

🤖 Generated with [Claude Code](https://claude.com/claude-code)