### PR TITLE
feat(usecase): migrate all use cases to suspend/Flow (D1.3)

### DIFF
--- a/core/repository/src/main/kotlin/debts/core/usecase/AddDebtUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/AddDebtUseCase.kt
@@ -1,16 +1,13 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.await
-import kotlinx.coroutines.rx2.rxCompletable
 
 class AddDebtUseCase(
     private val repository: DebtsRepository,
     private val createDebtorUseCase: CreateDebtorUseCase
 ) {
 
-    fun execute(
+    suspend fun execute(
         debtorId: Long?,
         contactId: Long?,
         name: String,
@@ -18,14 +15,14 @@ class AddDebtUseCase(
         currency: String,
         comment: String,
         date: Long
-    ): Completable = rxCompletable {
+    ) {
         val finalDebtorId: Long = if (debtorId != null) {
             debtorId
         } else {
             val debtors = repository.getDebtors()
             contactId?.let { cId -> debtors.firstOrNull { it.contactId == cId }?.id }
                 ?: debtors.firstOrNull { it.name == name }?.id
-                ?: createDebtorUseCase.execute(name, contactId).await()
+                ?: createDebtorUseCase.execute(name, contactId)
         }
         repository.saveDebt(finalDebtorId, amount, currency, comment, date)
     }

--- a/core/repository/src/main/kotlin/debts/core/usecase/ClearHistoryUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/ClearHistoryUseCase.kt
@@ -1,12 +1,10 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.rxCompletable
 
 class ClearHistoryUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(debtorId: Long): Completable = rxCompletable { repository.clearDebts(debtorId) }
+    suspend fun execute(debtorId: Long) = repository.clearDebts(debtorId)
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/CreateDebtorUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/CreateDebtorUseCase.kt
@@ -1,18 +1,16 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Single
-import kotlinx.coroutines.rx2.rxSingle
 
 class CreateDebtorUseCase(
     private val repository: DebtsRepository,
 ) {
-    fun execute(name: String, contactId: Long?): Single<Long> = rxSingle {
+    suspend fun execute(name: String, contactId: Long?): Long {
         val avatarUrl = if (contactId != null) {
             repository.getContacts().firstOrNull { it.id == contactId }?.avatarUrl ?: ""
         } else {
             ""
         }
-        repository.createDebtor(name, contactId, avatarUrl)
+        return repository.createDebtor(name, contactId, avatarUrl)
     }
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/GetContactsUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/GetContactsUseCase.kt
@@ -2,12 +2,10 @@ package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
 import debts.core.repository.data.ContactsItemModel
-import io.reactivex.Single
-import kotlinx.coroutines.rx2.rxSingle
 
 class GetContactsUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(): Single<List<ContactsItemModel>> = rxSingle { repository.getContacts() }
+    suspend fun execute(): List<ContactsItemModel> = repository.getContacts()
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/GetDebtUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/GetDebtUseCase.kt
@@ -2,12 +2,10 @@ package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
 import debts.core.repository.data.DebtModel
-import io.reactivex.Single
-import kotlinx.coroutines.rx2.rxSingle
 
 class GetDebtUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(id: Long): Single<DebtModel> = rxSingle { repository.getDebt(id) }
+    suspend fun execute(id: Long): DebtModel = repository.getDebt(id)
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/GetDebtsCsvContentUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/GetDebtsCsvContentUseCase.kt
@@ -2,15 +2,13 @@ package debts.core.usecase
 
 import debts.core.common.android.extensions.toSimpleDateTimeString
 import debts.core.repository.DebtsRepository
-import io.reactivex.Single
-import kotlinx.coroutines.rx2.rxSingle
 import java.util.Date
 
 class GetDebtsCsvContentUseCase(
     private val repository: DebtsRepository,
 ) {
 
-    fun execute(): Single<String> = rxSingle {
+    suspend fun execute(): String {
         val debtors = repository.getDebtors()
         val debts = repository.getDebts()
         val currency = repository.getCurrency()
@@ -22,6 +20,6 @@ class GetDebtsCsvContentUseCase(
                 sb.append("\n${Date(debt.date).toSimpleDateTimeString()},\t${debtor.name},\t${debt.amount},\t$currency,\t${debt.comment}")
             }
         }
-        sb.toString()
+        return sb.toString()
     }
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/GetShareDebtorContentUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/GetShareDebtorContentUseCase.kt
@@ -2,10 +2,8 @@ package debts.core.usecase
 
 import debts.core.common.android.extensions.toFormattedCurrency
 import debts.core.repository.DebtsRepository
-import io.reactivex.Single
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.rx2.rxSingle
 import timber.log.Timber
 import kotlin.math.absoluteValue
 
@@ -13,17 +11,17 @@ class GetShareDebtorContentUseCase(
     private val repository: DebtsRepository,
 ) {
 
-    fun execute(
+    suspend fun execute(
         debtorId: Long,
         templateBorrowed: String,
         templateLent: String,
-    ): Single<String> = rxSingle {
+    ): String {
         val debtor = repository.observeDebtor(debtorId).filterNotNull().first()
         val debts = repository.getDebts(debtorId)
         val currency = repository.getCurrency()
         val amount = debts.sumOf { it.amount }
         val isBorrowed = amount < 0
-        runCatching {
+        return runCatching {
             String.format(
                 if (isBorrowed) templateBorrowed else templateLent,
                 debtor.name,

--- a/core/repository/src/main/kotlin/debts/core/usecase/ObserveDebtorUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/ObserveDebtorUseCase.kt
@@ -2,17 +2,16 @@ package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
 import debts.core.usecase.data.DebtorDetailsModel
-import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.rx2.asObservable
 
 class ObserveDebtorUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(debtorId: Long): Observable<DebtorDetailsModel> =
+    fun execute(debtorId: Long): Flow<DebtorDetailsModel> =
         combine(
             repository.observeDebtor(debtorId).filterNotNull(),
             repository.observeDebts(debtorId).onStart { emit(emptyList()) },
@@ -24,5 +23,5 @@ class ObserveDebtorUseCase(
                 currency,
                 debtor.avatarUrl
             )
-        }.asObservable()
+        }
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/ObserveDebtorsListItemsUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/ObserveDebtorsListItemsUseCase.kt
@@ -3,15 +3,14 @@ package debts.core.usecase
 import debts.core.repository.DebtsRepository
 import debts.core.usecase.data.DebtorsListItemModel
 import debts.core.usecase.data.TabTypes
-import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.rx2.asObservable
 
 class ObserveDebtorsListItemsUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(tabType: TabTypes): Observable<List<DebtorsListItemModel.Debtor>> =
+    fun execute(tabType: TabTypes): Flow<List<DebtorsListItemModel.Debtor>> =
         combine(
             repository.observeDebtors(),
             repository.observeDebts(),
@@ -34,5 +33,5 @@ class ObserveDebtorsListItemsUseCase(
                         (tabType == TabTypes.Debtors && debtor.amount >= 0) ||
                         (tabType == TabTypes.Creditors && debtor.amount < 0)
             }
-        }.asObservable()
+        }
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/ObserveDebtsUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/ObserveDebtsUseCase.kt
@@ -2,18 +2,16 @@ package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
 import debts.core.usecase.data.DebtItemModel
-import io.reactivex.Observable
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.rx2.asObservable
 
 class ObserveDebtsUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(debtorId: Long): Observable<List<DebtItemModel>> =
+    fun execute(debtorId: Long): Flow<List<DebtItemModel>> =
         repository.observeDebts(debtorId)
             .map { items ->
                 items.map { DebtItemModel(it.id, it.amount, it.currency, it.date, it.comment) }
             }
-            .asObservable()
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/RemoveDebtUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/RemoveDebtUseCase.kt
@@ -1,12 +1,10 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.rxCompletable
 
 class RemoveDebtUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(id: Long): Completable = rxCompletable { repository.removeDebt(id) }
+    suspend fun execute(id: Long) = repository.removeDebt(id)
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/RemoveDebtorUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/RemoveDebtorUseCase.kt
@@ -1,11 +1,9 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.rxCompletable
 
 class RemoveDebtorUseCase(
     private val repository: DebtsRepository
 ) {
-    fun execute(debtorId: Long): Completable = rxCompletable { repository.removeDebtor(debtorId) }
+    suspend fun execute(debtorId: Long) = repository.removeDebtor(debtorId)
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/SyncDebtorsWithContactsUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/SyncDebtorsWithContactsUseCase.kt
@@ -1,8 +1,6 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.rxCompletable
 
 class SyncDebtorsWithContactsUseCase(
     private val repository: DebtsRepository
@@ -11,7 +9,7 @@ class SyncDebtorsWithContactsUseCase(
     /**
      * forceSync ignores preferences check
      */
-    fun execute(forceSync: Boolean = false): Completable = rxCompletable {
+    suspend fun execute(forceSync: Boolean = false) {
         val shouldSync = if (forceSync) true else !repository.isContactsSynced()
         if (shouldSync) {
             val debtors = repository.getDebtors().filter { it.contactId != null }

--- a/core/repository/src/main/kotlin/debts/core/usecase/UpdateDbDebtsCurrencyUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/UpdateDbDebtsCurrencyUseCase.kt
@@ -1,12 +1,10 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.rxCompletable
 
 class UpdateDbDebtsCurrencyUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(): Completable = rxCompletable { repository.updateDebtsCurrency() }
+    suspend fun execute() = repository.updateDebtsCurrency()
 }

--- a/core/repository/src/main/kotlin/debts/core/usecase/UpdateDebtUseCase.kt
+++ b/core/repository/src/main/kotlin/debts/core/usecase/UpdateDebtUseCase.kt
@@ -1,28 +1,24 @@
 package debts.core.usecase
 
 import debts.core.repository.DebtsRepository
-import io.reactivex.Completable
-import kotlinx.coroutines.rx2.rxCompletable
 
 class UpdateDebtUseCase(
     private val repository: DebtsRepository
 ) {
 
-    fun execute(
+    suspend fun execute(
         id: Long,
         debtorId: Long,
         amount: Double,
         date: Long,
         currency: String,
         comment: String
-    ): Completable = rxCompletable {
-        repository.updateDebt(
-            id = id,
-            debtorId = debtorId,
-            amount = amount,
-            currency = currency,
-            date = date,
-            comment = comment
-        )
-    }
+    ) = repository.updateDebt(
+        id = id,
+        debtorId = debtorId,
+        amount = amount,
+        currency = currency,
+        date = date,
+        comment = comment
+    )
 }

--- a/core/repository/src/test/kotlin/debts/core/usecase/AddDebtUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/AddDebtUseCaseTest.kt
@@ -20,8 +20,13 @@ class AddDebtUseCaseTest {
     @Test
     fun `uses provided debtorId directly without querying`() = runTest {
         useCase.execute(
-            debtorId = 5L, contactId = null, name = "Alice",
-            amount = 100.0, currency = "USD", comment = "", date = 0L
+            debtorId = 5L,
+            contactId = null,
+            name = "Alice",
+            amount = 100.0,
+            currency = "USD",
+            comment = "",
+            date = 0L
         )
 
         coVerify(exactly = 0) { repository.getDebtors() }
@@ -33,8 +38,13 @@ class AddDebtUseCaseTest {
         coEvery { repository.getDebtors() } returns listOf(debtor(3L, "Alice", contactId = 10L))
 
         useCase.execute(
-            debtorId = null, contactId = 10L, name = "Alice",
-            amount = 50.0, currency = "EUR", comment = "lunch", date = 1000L
+            debtorId = null,
+            contactId = 10L,
+            name = "Alice",
+            amount = 50.0,
+            currency = "EUR",
+            comment = "lunch",
+            date = 1000L
         )
 
         coVerify(exactly = 0) { createDebtorUseCase.execute(any(), any()) }
@@ -46,8 +56,13 @@ class AddDebtUseCaseTest {
         coEvery { repository.getDebtors() } returns listOf(debtor(4L, "Bob", contactId = null))
 
         useCase.execute(
-            debtorId = null, contactId = null, name = "Bob",
-            amount = 20.0, currency = "USD", comment = "", date = 0L
+            debtorId = null,
+            contactId = null,
+            name = "Bob",
+            amount = 20.0,
+            currency = "USD",
+            comment = "",
+            date = 0L
         )
 
         coVerify(exactly = 0) { createDebtorUseCase.execute(any(), any()) }
@@ -60,8 +75,13 @@ class AddDebtUseCaseTest {
         coEvery { createDebtorUseCase.execute("NewPerson", null) } returns 7L
 
         useCase.execute(
-            debtorId = null, contactId = null, name = "NewPerson",
-            amount = 75.0, currency = "USD", comment = "book", date = 5000L
+            debtorId = null,
+            contactId = null,
+            name = "NewPerson",
+            amount = 75.0,
+            currency = "USD",
+            comment = "book",
+            date = 5000L
         )
 
         coVerify { createDebtorUseCase.execute("NewPerson", null) }
@@ -76,8 +96,13 @@ class AddDebtUseCaseTest {
         )
 
         useCase.execute(
-            debtorId = null, contactId = 10L, name = "Bob",
-            amount = 10.0, currency = "USD", comment = "", date = 0L
+            debtorId = null,
+            contactId = 10L,
+            name = "Bob",
+            amount = 10.0,
+            currency = "USD",
+            comment = "",
+            date = 0L
         )
 
         // Should use debtor 1 (matched by contactId), not debtor 2 (matched by name)

--- a/core/repository/src/test/kotlin/debts/core/usecase/AddDebtUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/AddDebtUseCaseTest.kt
@@ -1,0 +1,86 @@
+package debts.core.usecase
+
+import debts.core.repository.DebtsRepository
+import debts.core.repository.data.DebtorModel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class AddDebtUseCaseTest {
+
+    private val repository: DebtsRepository = mockk(relaxed = true)
+    private val createDebtorUseCase: CreateDebtorUseCase = mockk()
+    private val useCase = AddDebtUseCase(repository, createDebtorUseCase)
+
+    private fun debtor(id: Long, name: String, contactId: Long? = null) =
+        DebtorModel(id = id, name = name, contactId = contactId, avatarUrl = "")
+
+    @Test
+    fun `uses provided debtorId directly without querying`() = runTest {
+        useCase.execute(
+            debtorId = 5L, contactId = null, name = "Alice",
+            amount = 100.0, currency = "USD", comment = "", date = 0L
+        )
+
+        coVerify(exactly = 0) { repository.getDebtors() }
+        coVerify { repository.saveDebt(5L, 100.0, "USD", "", 0L) }
+    }
+
+    @Test
+    fun `finds existing debtor by contactId`() = runTest {
+        coEvery { repository.getDebtors() } returns listOf(debtor(3L, "Alice", contactId = 10L))
+
+        useCase.execute(
+            debtorId = null, contactId = 10L, name = "Alice",
+            amount = 50.0, currency = "EUR", comment = "lunch", date = 1000L
+        )
+
+        coVerify(exactly = 0) { createDebtorUseCase.execute(any(), any()) }
+        coVerify { repository.saveDebt(3L, 50.0, "EUR", "lunch", 1000L) }
+    }
+
+    @Test
+    fun `finds existing debtor by name when contactId has no match`() = runTest {
+        coEvery { repository.getDebtors() } returns listOf(debtor(4L, "Bob", contactId = null))
+
+        useCase.execute(
+            debtorId = null, contactId = null, name = "Bob",
+            amount = 20.0, currency = "USD", comment = "", date = 0L
+        )
+
+        coVerify(exactly = 0) { createDebtorUseCase.execute(any(), any()) }
+        coVerify { repository.saveDebt(4L, 20.0, "USD", "", 0L) }
+    }
+
+    @Test
+    fun `creates new debtor when no existing match found`() = runTest {
+        coEvery { repository.getDebtors() } returns emptyList()
+        coEvery { createDebtorUseCase.execute("NewPerson", null) } returns 7L
+
+        useCase.execute(
+            debtorId = null, contactId = null, name = "NewPerson",
+            amount = 75.0, currency = "USD", comment = "book", date = 5000L
+        )
+
+        coVerify { createDebtorUseCase.execute("NewPerson", null) }
+        coVerify { repository.saveDebt(7L, 75.0, "USD", "book", 5000L) }
+    }
+
+    @Test
+    fun `contactId match takes priority over name match`() = runTest {
+        coEvery { repository.getDebtors() } returns listOf(
+            debtor(1L, "Alice", contactId = 10L),
+            debtor(2L, "Bob", contactId = null)
+        )
+
+        useCase.execute(
+            debtorId = null, contactId = 10L, name = "Bob",
+            amount = 10.0, currency = "USD", comment = "", date = 0L
+        )
+
+        // Should use debtor 1 (matched by contactId), not debtor 2 (matched by name)
+        coVerify { repository.saveDebt(1L, any(), any(), any(), any()) }
+    }
+}

--- a/core/repository/src/test/kotlin/debts/core/usecase/GetDebtsCsvContentUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/GetDebtsCsvContentUseCaseTest.kt
@@ -1,0 +1,77 @@
+package debts.core.usecase
+
+import debts.core.repository.DebtsRepository
+import debts.core.repository.data.DebtModel
+import debts.core.repository.data.DebtorModel
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class GetDebtsCsvContentUseCaseTest {
+
+    private val repository: DebtsRepository = mockk()
+    private val useCase = GetDebtsCsvContentUseCase(repository)
+
+    @Test
+    fun `output starts with CSV header`() = runTest {
+        coEvery { repository.getDebtors() } returns emptyList()
+        coEvery { repository.getDebts() } returns emptyList()
+        coEvery { repository.getCurrency() } returns "USD"
+
+        val result = useCase.execute()
+
+        assertTrue(result.startsWith("Date,\tName,\tAmount,\tCurrency,\tComment"))
+    }
+
+    @Test
+    fun `each debt produces a row with debtor name`() = runTest {
+        val debtor = DebtorModel(id = 1L, name = "Alice", contactId = null, avatarUrl = "")
+        val debt = DebtModel(id = 1L, debtorId = 1L, amount = 100.0, currency = "USD", date = 0L, comment = "coffee")
+        coEvery { repository.getDebtors() } returns listOf(debtor)
+        coEvery { repository.getDebts() } returns listOf(debt)
+        coEvery { repository.getCurrency() } returns "USD"
+
+        val result = useCase.execute()
+        val lines = result.lines()
+
+        assertTrue(lines.size == 2, "Expected header + 1 row, got ${lines.size}")
+        assertTrue(lines[1].contains("Alice"))
+        assertTrue(lines[1].contains("100.0"))
+        assertTrue(lines[1].contains("coffee"))
+    }
+
+    @Test
+    fun `debts with unknown debtorId are skipped`() = runTest {
+        val debtor = DebtorModel(id = 1L, name = "Alice", contactId = null, avatarUrl = "")
+        val orphanDebt = DebtModel(id = 2L, debtorId = 99L, amount = 50.0, currency = "USD", date = 0L, comment = "")
+        coEvery { repository.getDebtors() } returns listOf(debtor)
+        coEvery { repository.getDebts() } returns listOf(orphanDebt)
+        coEvery { repository.getCurrency() } returns "USD"
+
+        val result = useCase.execute()
+
+        assertTrue(result.lines().size == 1, "Orphan debt should not produce a row")
+    }
+
+    @Test
+    fun `multiple debts produce multiple rows`() = runTest {
+        val debtors = listOf(
+            DebtorModel(1L, "Alice", null, ""),
+            DebtorModel(2L, "Bob", null, "")
+        )
+        val debts = listOf(
+            DebtModel(1L, 1L, 10.0, "USD", 0L, ""),
+            DebtModel(2L, 1L, 20.0, "USD", 0L, ""),
+            DebtModel(3L, 2L, 30.0, "USD", 0L, "")
+        )
+        coEvery { repository.getDebtors() } returns debtors
+        coEvery { repository.getDebts() } returns debts
+        coEvery { repository.getCurrency() } returns "USD"
+
+        val result = useCase.execute()
+
+        assertTrue(result.lines().size == 4, "Expected header + 3 rows")
+    }
+}

--- a/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorUseCaseTest.kt
@@ -20,10 +20,12 @@ class ObserveDebtorUseCaseTest {
     fun `combines debtor debts and currency into DebtorDetailsModel`() = runTest {
         val debtor = DebtorModel(1L, "Alice", null, "avatar.png")
         every { repository.observeDebtor(1L) } returns flowOf(debtor)
-        every { repository.observeDebts(1L) } returns flowOf(listOf(
-            DebtModel(1L, 1L, 100.0, "USD", 0L, ""),
-            DebtModel(2L, 1L, 50.0, "USD", 0L, "")
-        ))
+        every { repository.observeDebts(1L) } returns flowOf(
+            listOf(
+                DebtModel(1L, 1L, 100.0, "USD", 0L, ""),
+                DebtModel(2L, 1L, 50.0, "USD", 0L, "")
+            )
+        )
         every { repository.observeCurrency() } returns flowOf("EUR")
 
         useCase.execute(1L).test {
@@ -53,9 +55,11 @@ class ObserveDebtorUseCaseTest {
     fun `negative amounts are summed correctly`() = runTest {
         val debtor = DebtorModel(1L, "Carol", null, "")
         every { repository.observeDebtor(1L) } returns flowOf(debtor)
-        every { repository.observeDebts(1L) } returns flowOf(listOf(
-            DebtModel(1L, 1L, -200.0, "USD", 0L, "")
-        ))
+        every { repository.observeDebts(1L) } returns flowOf(
+            listOf(
+                DebtModel(1L, 1L, -200.0, "USD", 0L, "")
+            )
+        )
         every { repository.observeCurrency() } returns flowOf("USD")
 
         useCase.execute(1L).test {

--- a/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorUseCaseTest.kt
@@ -1,0 +1,66 @@
+package debts.core.usecase
+
+import app.cash.turbine.test
+import debts.core.repository.DebtsRepository
+import debts.core.repository.data.DebtModel
+import debts.core.repository.data.DebtorModel
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ObserveDebtorUseCaseTest {
+
+    private val repository: DebtsRepository = mockk()
+    private val useCase = ObserveDebtorUseCase(repository)
+
+    @Test
+    fun `combines debtor debts and currency into DebtorDetailsModel`() = runTest {
+        val debtor = DebtorModel(1L, "Alice", null, "avatar.png")
+        every { repository.observeDebtor(1L) } returns flowOf(debtor)
+        every { repository.observeDebts(1L) } returns flowOf(listOf(
+            DebtModel(1L, 1L, 100.0, "USD", 0L, ""),
+            DebtModel(2L, 1L, 50.0, "USD", 0L, "")
+        ))
+        every { repository.observeCurrency() } returns flowOf("EUR")
+
+        useCase.execute(1L).test {
+            val model = awaitItem()
+            assertEquals("Alice", model.name)
+            assertEquals(150.0, model.amount)
+            assertEquals("EUR", model.currency)
+            assertEquals("avatar.png", model.avatarUrl)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `amount is zero when debtor has no debts`() = runTest {
+        val debtor = DebtorModel(1L, "Bob", null, "")
+        every { repository.observeDebtor(1L) } returns flowOf(debtor)
+        every { repository.observeDebts(1L) } returns flowOf(emptyList())
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(1L).test {
+            assertEquals(0.0, awaitItem().amount)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `negative amounts are summed correctly`() = runTest {
+        val debtor = DebtorModel(1L, "Carol", null, "")
+        every { repository.observeDebtor(1L) } returns flowOf(debtor)
+        every { repository.observeDebts(1L) } returns flowOf(listOf(
+            DebtModel(1L, 1L, -200.0, "USD", 0L, "")
+        ))
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(1L).test {
+            assertEquals(-200.0, awaitItem().amount)
+            awaitComplete()
+        }
+    }
+}

--- a/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorsListItemsUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorsListItemsUseCaseTest.kt
@@ -1,0 +1,151 @@
+package debts.core.usecase
+
+import app.cash.turbine.test
+import debts.core.repository.DebtsRepository
+import debts.core.repository.data.DebtModel
+import debts.core.repository.data.DebtorModel
+import debts.core.usecase.data.TabTypes
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ObserveDebtorsListItemsUseCaseTest {
+
+    private val repository: DebtsRepository = mockk()
+    private val useCase = ObserveDebtorsListItemsUseCase(repository)
+
+    private fun debtor(id: Long, name: String) =
+        DebtorModel(id = id, name = name, contactId = null, avatarUrl = "")
+
+    private fun debt(id: Long, debtorId: Long, amount: Double, currency: String = "USD", date: Long = 1000L) =
+        DebtModel(id = id, debtorId = debtorId, amount = amount, currency = currency, date = date, comment = "")
+
+    @Test
+    fun `TabTypes All returns all debtors`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice"), debtor(2, "Bob")))
+        every { repository.observeDebts() } returns flowOf(emptyList())
+        every { repository.observeCurrency() } returns flowOf("EUR")
+
+        useCase.execute(TabTypes.All).test {
+            val items = awaitItem()
+            assertEquals(2, items.size)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `TabTypes Debtors filters out creditors`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice"), debtor(2, "Bob")))
+        every { repository.observeDebts() } returns flowOf(listOf(
+            debt(1, 1L, 50.0),   // Alice owes → positive amount → Debtor
+            debt(2, 2L, -30.0)   // Bob lent → negative → Creditor
+        ))
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(TabTypes.Debtors).test {
+            val items = awaitItem()
+            assertEquals(1, items.size)
+            assertEquals("Alice", items[0].name)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `TabTypes Creditors filters out debtors`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice"), debtor(2, "Bob")))
+        every { repository.observeDebts() } returns flowOf(listOf(
+            debt(1, 1L, 50.0),
+            debt(2, 2L, -30.0)
+        ))
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(TabTypes.Creditors).test {
+            val items = awaitItem()
+            assertEquals(1, items.size)
+            assertEquals("Bob", items[0].name)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `amount is sum of all debts for debtor`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
+        every { repository.observeDebts() } returns flowOf(listOf(
+            debt(1, 1L, 100.0),
+            debt(2, 1L, 50.0),
+            debt(3, 1L, -25.0)
+        ))
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(TabTypes.All).test {
+            val item = awaitItem()[0]
+            assertEquals(125.0, item.amount)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `currency is taken from last debt when available`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
+        every { repository.observeDebts() } returns flowOf(listOf(
+            debt(1, 1L, 10.0, currency = "EUR", date = 2000L),
+            debt(2, 1L, 10.0, currency = "GBP", date = 1000L)
+        ))
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(TabTypes.All).test {
+            val item = awaitItem()[0]
+            assertEquals("EUR", item.currency) // most recent debt (date=2000)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `currency falls back to default when debtor has no debts`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
+        every { repository.observeDebts() } returns flowOf(emptyList())
+        every { repository.observeCurrency() } returns flowOf("CHF")
+
+        useCase.execute(TabTypes.All).test {
+            val item = awaitItem()[0]
+            assertEquals("CHF", item.currency)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `debts from other debtors are not included in amount`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
+        every { repository.observeDebts() } returns flowOf(listOf(
+            debt(1, 1L, 100.0),
+            debt(2, 99L, 999.0)  // belongs to debtor 99, not Alice
+        ))
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(TabTypes.All).test {
+            val item = awaitItem()[0]
+            assertEquals(100.0, item.amount)
+            awaitComplete()
+        }
+    }
+
+    @Test
+    fun `zero-debt debtor appears in All and Debtors tabs`() = runTest {
+        every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
+        every { repository.observeDebts() } returns flowOf(emptyList())
+        every { repository.observeCurrency() } returns flowOf("USD")
+
+        useCase.execute(TabTypes.All).test {
+            assertTrue(awaitItem().isNotEmpty())
+            awaitComplete()
+        }
+        useCase.execute(TabTypes.Debtors).test {
+            assertTrue(awaitItem().isNotEmpty()) // amount == 0 → >= 0 → Debtors
+            awaitComplete()
+        }
+    }
+}

--- a/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorsListItemsUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/ObserveDebtorsListItemsUseCaseTest.kt
@@ -40,10 +40,12 @@ class ObserveDebtorsListItemsUseCaseTest {
     @Test
     fun `TabTypes Debtors filters out creditors`() = runTest {
         every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice"), debtor(2, "Bob")))
-        every { repository.observeDebts() } returns flowOf(listOf(
-            debt(1, 1L, 50.0),   // Alice owes → positive amount → Debtor
-            debt(2, 2L, -30.0)   // Bob lent → negative → Creditor
-        ))
+        every { repository.observeDebts() } returns flowOf(
+            listOf(
+                debt(1, 1L, 50.0), // Alice owes → positive amount → Debtor
+                debt(2, 2L, -30.0) // Bob lent → negative → Creditor
+            )
+        )
         every { repository.observeCurrency() } returns flowOf("USD")
 
         useCase.execute(TabTypes.Debtors).test {
@@ -57,10 +59,12 @@ class ObserveDebtorsListItemsUseCaseTest {
     @Test
     fun `TabTypes Creditors filters out debtors`() = runTest {
         every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice"), debtor(2, "Bob")))
-        every { repository.observeDebts() } returns flowOf(listOf(
-            debt(1, 1L, 50.0),
-            debt(2, 2L, -30.0)
-        ))
+        every { repository.observeDebts() } returns flowOf(
+            listOf(
+                debt(1, 1L, 50.0),
+                debt(2, 2L, -30.0)
+            )
+        )
         every { repository.observeCurrency() } returns flowOf("USD")
 
         useCase.execute(TabTypes.Creditors).test {
@@ -74,11 +78,13 @@ class ObserveDebtorsListItemsUseCaseTest {
     @Test
     fun `amount is sum of all debts for debtor`() = runTest {
         every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
-        every { repository.observeDebts() } returns flowOf(listOf(
-            debt(1, 1L, 100.0),
-            debt(2, 1L, 50.0),
-            debt(3, 1L, -25.0)
-        ))
+        every { repository.observeDebts() } returns flowOf(
+            listOf(
+                debt(1, 1L, 100.0),
+                debt(2, 1L, 50.0),
+                debt(3, 1L, -25.0)
+            )
+        )
         every { repository.observeCurrency() } returns flowOf("USD")
 
         useCase.execute(TabTypes.All).test {
@@ -91,10 +97,12 @@ class ObserveDebtorsListItemsUseCaseTest {
     @Test
     fun `currency is taken from last debt when available`() = runTest {
         every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
-        every { repository.observeDebts() } returns flowOf(listOf(
-            debt(1, 1L, 10.0, currency = "EUR", date = 2000L),
-            debt(2, 1L, 10.0, currency = "GBP", date = 1000L)
-        ))
+        every { repository.observeDebts() } returns flowOf(
+            listOf(
+                debt(1, 1L, 10.0, currency = "EUR", date = 2000L),
+                debt(2, 1L, 10.0, currency = "GBP", date = 1000L)
+            )
+        )
         every { repository.observeCurrency() } returns flowOf("USD")
 
         useCase.execute(TabTypes.All).test {
@@ -120,10 +128,12 @@ class ObserveDebtorsListItemsUseCaseTest {
     @Test
     fun `debts from other debtors are not included in amount`() = runTest {
         every { repository.observeDebtors() } returns flowOf(listOf(debtor(1, "Alice")))
-        every { repository.observeDebts() } returns flowOf(listOf(
-            debt(1, 1L, 100.0),
-            debt(2, 99L, 999.0)  // belongs to debtor 99, not Alice
-        ))
+        every { repository.observeDebts() } returns flowOf(
+            listOf(
+                debt(1, 1L, 100.0),
+                debt(2, 99L, 999.0) // belongs to debtor 99, not Alice
+            )
+        )
         every { repository.observeCurrency() } returns flowOf("USD")
 
         useCase.execute(TabTypes.All).test {

--- a/core/repository/src/test/kotlin/debts/core/usecase/SyncDebtorsWithContactsUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/SyncDebtorsWithContactsUseCaseTest.kt
@@ -5,7 +5,6 @@ import debts.core.repository.data.ContactsItemModel
 import debts.core.repository.data.DebtorModel
 import io.mockk.coEvery
 import io.mockk.coVerify
-import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -65,11 +64,13 @@ class SyncDebtorsWithContactsUseCaseTest {
         useCase.execute()
 
         coVerify {
-            repository.updateDebtors(match { items ->
-                items.size == 1 &&
-                        items[0].name == "Alice" &&
-                        items[0].avatarUrl == "new_avatar"
-            })
+            repository.updateDebtors(
+                match { items ->
+                    items.size == 1 &&
+                            items[0].name == "Alice" &&
+                            items[0].avatarUrl == "new_avatar"
+                }
+            )
         }
     }
 
@@ -86,11 +87,13 @@ class SyncDebtorsWithContactsUseCaseTest {
         useCase.execute()
 
         coVerify {
-            repository.updateDebtors(match { items ->
-                items.size == 1 &&
-                        items[0].contactId == 42L &&
-                        items[0].name == "New Name"
-            })
+            repository.updateDebtors(
+                match { items ->
+                    items.size == 1 &&
+                            items[0].contactId == 42L &&
+                            items[0].name == "New Name"
+                }
+            )
         }
     }
 

--- a/core/repository/src/test/kotlin/debts/core/usecase/SyncDebtorsWithContactsUseCaseTest.kt
+++ b/core/repository/src/test/kotlin/debts/core/usecase/SyncDebtorsWithContactsUseCaseTest.kt
@@ -1,0 +1,133 @@
+package debts.core.usecase
+
+import debts.core.repository.DebtsRepository
+import debts.core.repository.data.ContactsItemModel
+import debts.core.repository.data.DebtorModel
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+class SyncDebtorsWithContactsUseCaseTest {
+
+    private val repository: DebtsRepository = mockk(relaxed = true)
+    private val useCase = SyncDebtorsWithContactsUseCase(repository)
+
+    private fun debtor(id: Long, name: String, contactId: Long? = null) =
+        DebtorModel(id = id, name = name, contactId = contactId, avatarUrl = "")
+
+    private fun contact(id: Long, name: String, avatarUrl: String = "avatar_$id") =
+        ContactsItemModel(id = id, name = name, avatarUrl = avatarUrl)
+
+    @Test
+    fun `skips sync when already synced and forceSync is false`() = runTest {
+        coEvery { repository.isContactsSynced() } returns true
+
+        useCase.execute(forceSync = false)
+
+        coVerify(exactly = 0) { repository.getDebtors() }
+        coVerify { repository.setContactsSynced(true) }
+    }
+
+    @Test
+    fun `performs sync when not yet synced`() = runTest {
+        coEvery { repository.isContactsSynced() } returns false
+        coEvery { repository.getDebtors() } returns listOf(debtor(1, "Alice", contactId = 10))
+        coEvery { repository.getContacts() } returns listOf(contact(10, "Alice"))
+
+        useCase.execute(forceSync = false)
+
+        coVerify { repository.getDebtors() }
+    }
+
+    @Test
+    fun `performs sync when forceSync is true regardless of preference`() = runTest {
+        coEvery { repository.isContactsSynced() } returns true
+        coEvery { repository.getDebtors() } returns emptyList()
+
+        useCase.execute(forceSync = true)
+
+        coVerify { repository.getDebtors() }
+    }
+
+    @Test
+    fun `matches contact by name and updates debtor`() = runTest {
+        coEvery { repository.isContactsSynced() } returns false
+        coEvery { repository.getDebtors() } returns listOf(
+            debtor(1, "Alice", contactId = 10)
+        )
+        coEvery { repository.getContacts() } returns listOf(
+            contact(10, "Alice", avatarUrl = "new_avatar")
+        )
+
+        useCase.execute()
+
+        coVerify {
+            repository.updateDebtors(match { items ->
+                items.size == 1 &&
+                        items[0].name == "Alice" &&
+                        items[0].avatarUrl == "new_avatar"
+            })
+        }
+    }
+
+    @Test
+    fun `matches contact by id when name does not match`() = runTest {
+        coEvery { repository.isContactsSynced() } returns false
+        coEvery { repository.getDebtors() } returns listOf(
+            debtor(1, "Old Name", contactId = 42)
+        )
+        coEvery { repository.getContacts() } returns listOf(
+            contact(42, "New Name", avatarUrl = "avatar_42")
+        )
+
+        useCase.execute()
+
+        coVerify {
+            repository.updateDebtors(match { items ->
+                items.size == 1 &&
+                        items[0].contactId == 42L &&
+                        items[0].name == "New Name"
+            })
+        }
+    }
+
+    @Test
+    fun `skips debtors without contactId`() = runTest {
+        coEvery { repository.isContactsSynced() } returns false
+        coEvery { repository.getDebtors() } returns listOf(
+            debtor(1, "Alice", contactId = null)
+        )
+
+        useCase.execute()
+
+        coVerify(exactly = 0) { repository.getContacts() }
+        coVerify(exactly = 0) { repository.updateDebtors(any()) }
+    }
+
+    @Test
+    fun `does not call updateDebtors when no contacts match`() = runTest {
+        coEvery { repository.isContactsSynced() } returns false
+        coEvery { repository.getDebtors() } returns listOf(
+            debtor(1, "Alice", contactId = 10)
+        )
+        coEvery { repository.getContacts() } returns listOf(
+            contact(99, "Someone Else")
+        )
+
+        useCase.execute()
+
+        coVerify(exactly = 0) { repository.updateDebtors(any()) }
+    }
+
+    @Test
+    fun `always calls setContactsSynced at the end`() = runTest {
+        coEvery { repository.isContactsSynced() } returns true
+
+        useCase.execute(forceSync = false)
+
+        coVerify { repository.setContactsSynced(true) }
+    }
+}

--- a/feature/details/src/main/kotlin/debts/feature/details/mvi/DetailsInteractor.kt
+++ b/feature/details/src/main/kotlin/debts/feature/details/mvi/DetailsInteractor.kt
@@ -70,7 +70,13 @@ class DetailsInteractor(
                     .flatMapCompletable { currency ->
                         rxCompletable {
                             addDebtUseCase.execute(
-                                action.debtorId, null, "", action.amount, currency, action.comment, action.date
+                                action.debtorId,
+                                null,
+                                "",
+                                action.amount,
+                                currency,
+                                action.comment,
+                                action.date
                             )
                         }
                     }

--- a/feature/details/src/main/kotlin/debts/feature/details/mvi/DetailsInteractor.kt
+++ b/feature/details/src/main/kotlin/debts/feature/details/mvi/DetailsInteractor.kt
@@ -15,6 +15,8 @@ import debts.core.usecase.UpdateDebtUseCase
 import io.reactivex.Observable
 import io.reactivex.ObservableTransformer
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.rx2.asObservable
+import kotlinx.coroutines.rx2.rxCompletable
 import kotlinx.coroutines.rx2.rxSingle
 import timber.log.Timber
 
@@ -38,14 +40,10 @@ class DetailsInteractor(
         ObservableTransformer<DetailsAction.Init, DetailsResult> { actions ->
             actions.switchMap { action ->
                 Observable.merge(
-                    observeDebtorUseCase.execute(action.id)
-                        .map {
-                            DetailsResult.Debtor(it.name, it.amount, it.currency, it.avatarUrl)
-                        },
-                    observeDebtsUseCase.execute(action.id)
-                        .map { items ->
-                            DetailsResult.History(items.map { it })
-                        }
+                    observeDebtorUseCase.execute(action.id).asObservable()
+                        .map { DetailsResult.Debtor(it.name, it.amount, it.currency, it.avatarUrl) },
+                    observeDebtsUseCase.execute(action.id).asObservable()
+                        .map { items -> DetailsResult.History(items.map { it }) }
                 )
                     .subscribeOn(Schedulers.io())
                     .doOnError { Timber.e(it) }
@@ -56,8 +54,7 @@ class DetailsInteractor(
     private val clearHistoryProcessor =
         ObservableTransformer<DetailsAction.ClearHistory, DetailsResult> { actions ->
             actions.switchMap { action ->
-                clearHistoryUseCase
-                    .execute(action.id)
+                rxCompletable { clearHistoryUseCase.execute(action.id) }
                     .subscribeOn(Schedulers.io())
                     .doOnError { Timber.e(it) }
                     .toSingleDefault(DetailsResult.History(emptyList()) as DetailsResult)
@@ -71,16 +68,11 @@ class DetailsInteractor(
             actions.switchMap { action ->
                 rxSingle { repository.getCurrency() }
                     .flatMapCompletable { currency ->
-                        addDebtUseCase
-                            .execute(
-                                action.debtorId,
-                                null,
-                                "",
-                                action.amount,
-                                currency,
-                                action.comment,
-                                action.date
+                        rxCompletable {
+                            addDebtUseCase.execute(
+                                action.debtorId, null, "", action.amount, currency, action.comment, action.date
                             )
+                        }
                     }
                     .doOnComplete {
                         // TODO: this resource id should be provided from Fragment through intent/action
@@ -95,9 +87,8 @@ class DetailsInteractor(
 
     private val removeDebtProcessor =
         ObservableTransformer<DetailsAction.RemoveDebt, DetailsResult> { actions ->
-            actions.switchMap {
-                removeDebtUseCase
-                    .execute(it.id)
+            actions.switchMap { action ->
+                rxCompletable { removeDebtUseCase.execute(action.id) }
                     .subscribeOn(Schedulers.io())
                     .toObservable<DetailsResult>()
                     .doOnError { error -> Timber.e(error) }
@@ -107,13 +98,12 @@ class DetailsInteractor(
 
     private val editDebtProcessor =
         ObservableTransformer<DetailsAction.EditDebt, DetailsResult> { actions ->
-            actions.switchMap {
-                getDebtUseCase
-                    .execute(it.id)
+            actions.switchMap { action ->
+                rxSingle { getDebtUseCase.execute(action.id) }
                     .subscribeOn(Schedulers.io())
                     .map { debtModel ->
                         DetailsResult.EditDebt(
-                            debtId = it.id,
+                            debtId = action.id,
                             amount = debtModel.amount,
                             comment = debtModel.comment,
                             date = debtModel.date
@@ -127,20 +117,20 @@ class DetailsInteractor(
 
     private val editDebtSaveProcessor =
         ObservableTransformer<DetailsAction.EditDebtSave, DetailsResult> { actions ->
-            actions.switchMap {
-                getDebtUseCase.execute(it.debtId)
+            actions.switchMap { action ->
+                rxSingle { getDebtUseCase.execute(action.debtId) }
                     .subscribeOn(Schedulers.io())
                     .flatMapCompletable { debtModel ->
-                        updateDebtUseCase
-                            .execute(
+                        rxCompletable {
+                            updateDebtUseCase.execute(
                                 id = debtModel.id,
                                 debtorId = debtModel.debtorId,
-                                amount = it.amount,
-                                date = it.date,
+                                amount = action.amount,
+                                date = action.date,
                                 currency = debtModel.currency,
-                                comment = it.comment
+                                comment = action.comment
                             )
-                            .doOnError { error -> Timber.e(error) }
+                        }.doOnError { error -> Timber.e(error) }
                     }
                     .doOnComplete {
                         // TODO: this resource id should be provided from Fragment through intent/action
@@ -154,9 +144,8 @@ class DetailsInteractor(
 
     private val removeDebtorProcessor =
         ObservableTransformer<DetailsAction.RemoveDebtor, DetailsResult> { actions ->
-            actions.switchMap {
-                removeDebtorUseCase
-                    .execute(it.debtorId)
+            actions.switchMap { action ->
+                rxCompletable { removeDebtorUseCase.execute(action.debtorId) }
                     .subscribeOn(Schedulers.io())
                     .toSingleDefault(DetailsResult.DebtorRemoved as DetailsResult)
                     .doOnError { error -> Timber.e(error) }
@@ -168,16 +157,15 @@ class DetailsInteractor(
     private val shareDebtorProcessor =
         ObservableTransformer<DetailsAction.ShareDebtor, DetailsResult> { actions ->
             actions.switchMap { action ->
-                getShareDebtorContentUseCase.execute(
-                    action.debtorId,
-                    action.borrowedTemplate,
-                    action.lentTemplate
-                )
+                rxSingle {
+                    getShareDebtorContentUseCase.execute(
+                        action.debtorId,
+                        action.borrowedTemplate,
+                        action.lentTemplate
+                    )
+                }
                     .flatMapCompletable { content ->
-                        debtsNavigator.sendExplicit(
-                            action.titleText,
-                            content
-                        )
+                        debtsNavigator.sendExplicit(action.titleText, content)
                     }
                     .subscribeOn(Schedulers.io())
                     .toObservable<DetailsResult>()

--- a/feature/home/src/main/kotlin/debts/feature/home/list/mvi/DebtorsInteractor.kt
+++ b/feature/home/src/main/kotlin/debts/feature/home/list/mvi/DebtorsInteractor.kt
@@ -14,6 +14,8 @@ import io.reactivex.ObservableTransformer
 import io.reactivex.functions.Function4
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.rx2.asObservable
+import kotlinx.coroutines.rx2.rxCompletable
+import kotlinx.coroutines.rx2.rxSingle
 import net.thebix.debts.feature.home.R
 import timber.log.Timber
 import kotlin.math.absoluteValue
@@ -31,7 +33,7 @@ class DebtorsInteractor(
             actions.switchMap { action ->
                 Observable.combineLatest<List<DebtorsListItemModel.Debtor>, SortType, String, String, Pair<Pair<String, Double>, List<DebtorsListItemModel>>>(
                     observeDebtorsListItemsUseCase
-                        .execute(action.tabType),
+                        .execute(action.tabType).asObservable(),
                     repository.observeSortType().asObservable(),
                     repository.observeDebtorsFilter().asObservable(),
                     repository.observeCurrency().asObservable(),
@@ -65,8 +67,7 @@ class DebtorsInteractor(
     private val removeDebtorProcessor =
         ObservableTransformer<DebtorsAction.RemoveDebtor, DebtorsResult> { actions ->
             actions.switchMap {
-                removeDebtorUseCase
-                    .execute(it.debtorId)
+                rxCompletable { removeDebtorUseCase.execute(it.debtorId) }
                     .subscribeOn(Schedulers.io())
                     .toObservable<DebtorsResult>()
                     .doOnError { error -> Timber.e(error) }
@@ -88,11 +89,13 @@ class DebtorsInteractor(
     private val shareDebtorProcessor =
         ObservableTransformer<DebtorsAction.ShareDebtor, DebtorsResult> { actions ->
             actions.switchMap { action ->
-                getShareDebtorContentUseCase.execute(
-                    action.debtorId,
-                    action.borrowedTemplate,
-                    action.lentTemplate
-                )
+                rxSingle {
+                    getShareDebtorContentUseCase.execute(
+                        action.debtorId,
+                        action.borrowedTemplate,
+                        action.lentTemplate
+                    )
+                }
                     .flatMapCompletable { content ->
                         debtsNavigator.sendExplicit(
                             action.titleText,

--- a/feature/home/src/main/kotlin/debts/feature/home/list/mvi/HomeInteractor.kt
+++ b/feature/home/src/main/kotlin/debts/feature/home/list/mvi/HomeInteractor.kt
@@ -42,7 +42,7 @@ class HomeInteractor(
                     .flatMapCompletable {
                         rxCompletable { repository.setCurrency(NumberFormat.getCurrencyInstance(Locale.getDefault()).currency.symbol) }
                     }
-                    .andThen(updateDbDebtsCurrencyUseCase.execute())
+                    .andThen(rxCompletable { updateDbDebtsCurrencyUseCase.execute() })
                     .andThen(rxCompletable { repository.setAppFirstStart(false) })
                     .toObservable<HomeResult>(),
                 checkContactsPermissionAndSyncWithContacts(action.contactPermission, action.requestCode)
@@ -105,7 +105,7 @@ class HomeInteractor(
     private val shareAllDebtsProcessor =
         ObservableTransformer<HomeAction.ShareAllDebts, HomeResult> { actions ->
             actions.switchMap { action ->
-                getDebtsCsvContentUseCase.execute()
+                rxSingle { getDebtsCsvContentUseCase.execute() }
                     .flatMapCompletable { content ->
                         debtsNavigator.sendExplicitFile(
                             action.titleText,
@@ -122,7 +122,7 @@ class HomeInteractor(
         }
 
     private fun checkContactsPermissionAndSyncWithContacts(contactPermission: String, requestCode: Int) =
-        observeDebtorsListItemsUseCase.execute(TabTypes.All)
+        observeDebtorsListItemsUseCase.execute(TabTypes.All).asObservable()
             .take(1)
             .singleElement()
             .filter { items -> items.any { it.name.isEmpty() } }
@@ -132,7 +132,7 @@ class HomeInteractor(
             }
             .flatMapCompletable { isContactsAccessGranted ->
                 if (isContactsAccessGranted) {
-                    syncDebtorsWithContactsUseCase.execute()
+                    rxCompletable { syncDebtorsWithContactsUseCase.execute() }
                 } else {
                     debtsNavigator.requestPermission(
                         contactPermission,
@@ -165,8 +165,7 @@ class HomeInteractor(
                 .onErrorReturnItem(HomeResult.ShowAddDebtDialog(emptyList()))
         }
 
-    private fun getContactsResult() = getContactsUseCase
-        .execute()
+    private fun getContactsResult() = rxSingle { getContactsUseCase.execute() }
         .flatMap { items ->
             Single.fromCallable { HomeResult.ShowAddDebtDialog(items) as HomeResult }
         }
@@ -174,11 +173,14 @@ class HomeInteractor(
 
     private val addDebtProcessor =
         ObservableTransformer<HomeAction.AddDebt, HomeResult> { actions ->
-            actions.switchMap {
+            actions.switchMap { action ->
                 rxSingle { repository.getCurrency() }
                     .flatMapCompletable { currency ->
-                        addDebtUseCase
-                            .execute(null, it.contactId, it.name, it.amount, currency, it.comment, it.date)
+                        rxCompletable {
+                            addDebtUseCase.execute(
+                                null, action.contactId, action.name, action.amount, currency, action.comment, action.date
+                            )
+                        }
                     }
                     .doOnComplete {
                         // TODO: this resource id should be provided from Fragment through intent/action

--- a/feature/home/src/main/kotlin/debts/feature/home/list/mvi/HomeInteractor.kt
+++ b/feature/home/src/main/kotlin/debts/feature/home/list/mvi/HomeInteractor.kt
@@ -178,7 +178,13 @@ class HomeInteractor(
                     .flatMapCompletable { currency ->
                         rxCompletable {
                             addDebtUseCase.execute(
-                                null, action.contactId, action.name, action.amount, currency, action.comment, action.date
+                                null,
+                                action.contactId,
+                                action.name,
+                                action.amount,
+                                currency,
+                                action.comment,
+                                action.date
                             )
                         }
                     }

--- a/feature/preferences/src/main/kotlin/debts/feature/preferences/mvi/MainSettingsInteractor.kt
+++ b/feature/preferences/src/main/kotlin/debts/feature/preferences/mvi/MainSettingsInteractor.kt
@@ -20,10 +20,12 @@ class MainSettingsInteractor(
 
     private val updateCurrencyProcessor =
         ObservableTransformer<MainSettingsAction.UpdateCurrency, MainSettingsResult> { actions ->
-            actions.switchMap {
-                updateDbDebtsCurrencyUseCase.execute()
+            actions.switchMap { action ->
+                rxCompletable {
+                    updateDbDebtsCurrencyUseCase.execute()
                     // to send new currency to all observers
-                    .andThen(rxCompletable { repository.setCurrency(it.currency) })
+                    repository.setCurrency(action.currency)
+                }
                     .subscribeOn(Schedulers.io())
                     .toSingleDefault(MainSettingsResult.UpdateCurrencyEnd as MainSettingsResult)
                     .doOnError { Timber.e(it) }
@@ -41,7 +43,7 @@ class MainSettingsInteractor(
                     .toObservable()
                     .flatMapSingle { (action, isContactsAccessGranted) ->
                         if (isContactsAccessGranted) {
-                            syncDebtorsWithContactsUseCase.execute(true)
+                            rxCompletable { syncDebtorsWithContactsUseCase.execute(true) }
                                 .toSingleDefault(MainSettingsResult.SyncWithContactsEnd as MainSettingsResult)
                         } else {
                             debtsNavigator.requestPermission(


### PR DESCRIPTION
## Summary

- **All 15 use cases**: public API migrated from `Single`/`Completable`/`Observable` to `suspend`/`Flow`; `rxSingle`/`rxCompletable`/`asObservable()` wrappers removed from the use case layer entirely
- **Interactors** (`feature:home`, `feature:details`, `feature:preferences`): coroutines bridged back to RxJava at the interactor boundary — temporary, dissolved in U2.x when each interactor becomes a ViewModel
- **5 new use case test classes** covering business logic:
  - `ObserveDebtorsListItemsUseCaseTest` — tab filtering (All/Debtors/Creditors), amount sum, currency fallback
  - `ObserveDebtorUseCaseTest` — Flow combine logic
  - `SyncDebtorsWithContactsUseCaseTest` — contact matching by name and by id, forceSync flag
  - `GetDebtsCsvContentUseCaseTest` — CSV header/row format, orphan debt exclusion
  - `AddDebtUseCaseTest` — debtor resolution (explicit id → contactId → name → create new)

## What stays RxJava

Interactors (`ObservableTransformer`-based MVI) are still RxJava — migration to `StateFlow` ViewModels happens per-feature in Epic 2 (U2.x).

## Test plan

- [ ] `./gradlew assembleDebug` — clean build
- [ ] `./gradlew test` — all unit tests pass
- [ ] Manual smoke: list loads, add debt, remove debtor, currency change, share

🤖 Generated with [Claude Code](https://claude.com/claude-code)