### PR TITLE
ci: post test coverage diff to PR comments

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,17 +3,10 @@ name: Android CI
 on:
   push:
     branches:
-      - '**'
-    tags-ignore:
-      - internal/*
-      - release/*
+      - master
   pull_request:
     branches:
       - '**'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
 
 jobs:
   static-analysis:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -7,6 +7,13 @@ on:
     tags-ignore:
       - internal/*
       - release/*
+  pull_request:
+    branches:
+      - '**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   static-analysis:
@@ -15,6 +22,8 @@ jobs:
   test:
     needs: static-analysis
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup environment
@@ -30,6 +39,16 @@ jobs:
         with:
           name: coverage-report
           path: '**/build/reports/kover/report.xml'
+      - name: Post coverage comment
+        if: github.event_name == 'pull_request'
+        uses: madrapps/jacoco-report@v1.7.1
+        with:
+          paths: '**/build/reports/kover/report.xml'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: Test Coverage
+          update-comment: true
+          min-coverage-overall: 0
+          min-coverage-changed-files: 0
   build:
     needs: static-analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,7 +12,7 @@ on:
       - '**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

- `pull_request` trigger added — workflow now fires on PR open/update in addition to push
- `concurrency` group added — cancels the redundant run when both `push` and `pull_request` fire for the same branch commit, so CI doesn't run twice per push to a PR branch
- `permissions: pull-requests: write` added to the `test` job — required for `GITHUB_TOKEN` to post comments
- `madrapps/jacoco-report@v1.7.1` step added — Kover XML format is JaCoCo-compatible; posts a markdown table with overall coverage % and a per-file breakdown for files changed in the PR; updates the same comment on each new push (no spam)
- Step is gated by `if: github.event_name == 'pull_request'` — never posts on pushes to master or other branches without a PR

## Thresholds

`min-coverage-overall` and `min-coverage-changed-files` are set to `0` — the comment is informational only and does not block merging. Will be raised to 80% as part of C4.1.

## Test plan

- [ ] Open any PR → CI finishes → coverage comment appears
- [ ] Push another commit to the same PR → comment updates in place, no new comment created
- [ ] Push to master directly → no coverage comment posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)