### PR TITLE
feat(mvvm): add BaseViewModel MVVM/UDF base (U2.0)

### DIFF
--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -13,7 +13,13 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.constraintlayout)
     implementation(libs.androidx.core)
+    implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.google.android.material)
     implementation(libs.bundles.rxjava)
     implementation(libs.androidx.preference)
+    implementation(libs.kotlinx.coroutines.core)
+
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
 }

--- a/core/common/src/main/kotlin/debts/core/common/android/mvvm/BaseViewModel.kt
+++ b/core/common/src/main/kotlin/debts/core/common/android/mvvm/BaseViewModel.kt
@@ -1,0 +1,30 @@
+package debts.core.common.android.mvvm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+abstract class BaseViewModel<S, E>(initialState: S) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(initialState)
+    val uiState: StateFlow<S> = _uiState.asStateFlow()
+
+    private val _events = Channel<E>(Channel.BUFFERED)
+    val events = _events.receiveAsFlow()
+
+    protected fun updateState(transform: S.() -> S) {
+        _uiState.update(transform)
+    }
+
+    protected fun sendEvent(event: E) {
+        viewModelScope.launch {
+            _events.send(event)
+        }
+    }
+}

--- a/core/common/src/test/kotlin/debts/core/common/android/mvvm/BaseViewModelTest.kt
+++ b/core/common/src/test/kotlin/debts/core/common/android/mvvm/BaseViewModelTest.kt
@@ -1,0 +1,92 @@
+package debts.core.common.android.mvvm
+
+import app.cash.turbine.test
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BaseViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private data class TestState(val value: Int = 0)
+
+    private sealed class TestEvent {
+        data class Message(val text: String) : TestEvent()
+    }
+
+    private class TestViewModel : BaseViewModel<TestState, TestEvent>(TestState()) {
+        fun increment() = updateState { copy(value = value + 1) }
+        fun emitMessage(text: String) = sendEvent(TestEvent.Message(text))
+    }
+
+    @Test
+    fun `initial state is set correctly`() {
+        val vm = TestViewModel()
+        assertEquals(TestState(0), vm.uiState.value)
+    }
+
+    @Test
+    fun `updateState transforms state`() {
+        val vm = TestViewModel()
+        vm.increment()
+        assertEquals(TestState(1), vm.uiState.value)
+    }
+
+    @Test
+    fun `multiple state updates accumulate correctly`() {
+        val vm = TestViewModel()
+        vm.increment()
+        vm.increment()
+        vm.increment()
+        assertEquals(TestState(3), vm.uiState.value)
+    }
+
+    @Test
+    fun `sendEvent delivers event to collector`() = runTest {
+        val vm = TestViewModel()
+        vm.events.test {
+            vm.emitMessage("hello")
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(TestEvent.Message("hello"), awaitItem())
+        }
+    }
+
+    @Test
+    fun `multiple events are delivered in order`() = runTest {
+        val vm = TestViewModel()
+        vm.events.test {
+            vm.emitMessage("first")
+            vm.emitMessage("second")
+            testDispatcher.scheduler.advanceUntilIdle()
+            assertEquals(TestEvent.Message("first"), awaitItem())
+            assertEquals(TestEvent.Message("second"), awaitItem())
+        }
+    }
+
+    @Test
+    fun `uiState reflects latest update`() {
+        val vm = TestViewModel()
+        vm.increment()
+        vm.increment()
+        assertEquals(2, vm.uiState.value.value)
+        vm.increment()
+        assertEquals(3, vm.uiState.value.value)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ androidx-appcompat = "1.6.1"
 androidx-compose-bom = "2026.06.00"
 androidx-constraintlayout = "2.2.1"
 androidx-core = "1.12.0"
+androidx-lifecycle = "2.9.1"
 androidx-preference = "1.2.1"
 androidx-recyclerview = "1.4.0"
 detekt = "1.23.8"
@@ -41,7 +42,9 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle" }
 androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }


### PR DESCRIPTION
## Summary

- Adds `BaseViewModel<S, E>` in `core:common` as the lightweight MVVM/UDF foundation for Epic 2 screen migrations
- `uiState: StateFlow<S>` — immutable state exposed to UI, updated via `updateState { ... }`
- `events: Flow<E>` — one-shot events (navigation, snackbar) delivered via a buffered `Channel`; each event consumed once
- Lives alongside the existing RxJava MVI base (`MviViewModel`) — old screens unchanged until their vertical slice migration
- Adds `lifecycle-viewmodel-ktx` and `kotlinx-coroutines-core` to version catalog
- 6 unit tests covering initial state, state transforms, event delivery and ordering

## Test plan

- [ ] `./gradlew :core:common:test` — all 6 tests green
- [ ] `./gradlew detekt` — no new violations
- [ ] `./gradlew build` — project builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)