### PR TITLE
build(kover): exclude Activities, Fragments and @Composable from coverage

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -31,6 +31,14 @@ dependencyResolutionManagement {
 
 kover {
     reports {
+        // Pure UI glue — no testable logic; business logic lives in ViewModels
+        excludedClasses.addAll(
+            "*Activity",
+            "*Fragment",
+        )
+        // Compose UI functions — declarative rendering, not business logic
+        excludesAnnotatedBy.add("androidx.compose.runtime.Composable")
+
         verify {
             rule {
                 // Starting threshold — raised incrementally as tests are added (ratchet)


### PR DESCRIPTION
## Summary

- Exclude `*Activity` and `*Fragment` classes from Kover coverage reports — these are UI glue with no testable logic; all meaningful business logic lives in ViewModels which are covered
- Exclude all functions annotated with `@Composable` — declarative UI rendering is not logic and shouldn't pollute the coverage metric
- Uses the Kover 0.9.8 aggregation DSL: `excludedClasses` for class patterns, `excludesAnnotatedBy` for annotation-based exclusion (no fragile filename heuristics)

## Test plan

- [ ] `./gradlew koverVerify` passes
- [ ] Coverage report no longer counts Activity/Fragment/Composable lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)